### PR TITLE
Fix Logic on conditionals, More PEP8 Fix

### DIFF
--- a/CSSOnDiet/cod.py
+++ b/CSSOnDiet/cod.py
@@ -8,12 +8,13 @@
 
 #{{{ import
 
-from __future__ import division  # for python2-3 compatibility
+from __future__ import division  # Compatibility
+
+import hashlib
+import math
 import re
 import sys
 from os import path
-import hashlib
-import math
 
 #}}}
 


### PR DESCRIPTION
- Fix Logic on conditionals.
- Fix PEP8 ~80 characters per line.
- Fix PEP8 Unneeded trailing backslashes between two parentheses.
- Use builtin isinstance() instead of type(obj) == type("")
- Fix PEP8 Use is instead of ==
- Alphabetical Sorted all Imports.
- Comments are not removed, just moved up if they are too long.

I try to keep the Diff not tooo large so its easy to review  :smile: 
